### PR TITLE
add means of reading tiles from a buffer

### DIFF
--- a/lib/vector_tile.dart
+++ b/lib/vector_tile.dart
@@ -1,4 +1,6 @@
+import 'dart:io';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:vector_tile/vector_tile_layer.dart';
 import 'package:vector_tile/raw/raw_vector_tile.dart' as raw;
@@ -19,11 +21,15 @@ class VectorTile {
   });
 
   static Future<VectorTile> fromPath({required String path}) async {
-    raw.VectorTile rawTile = await raw.decodeVectorTile(path: path);
-    List<VectorTileLayer> layers = rawTile.layers.map((rawLayer) {
+    return fromBytes(bytes: await File(path).readAsBytes());
+  }
+
+  /// decodes the given bytes (`.mvt`/`.pbf`) to a [VectorTile]
+  static VectorTile fromBytes({required Uint8List bytes}) {
+    final tile = raw.VectorTile.fromBuffer(bytes);
+    List<VectorTileLayer> layers = tile.layers.map((rawLayer) {
       return VectorTileLayer.fromRaw(rawLayer: rawLayer);
     }).toList();
-
     return VectorTile(layers: layers);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: vector_tile
-version: 0.2.0
+version: 0.2.1
 description: >-
   A simple Dart package to encode & decode Mapbox Vector Tile, A implementation of Mapbox Vector Tile specification.
 homepage: https://github.com/saigontek/dart-vector-tile


### PR DESCRIPTION
Enable reading from a buffer so that the library can be used without a filesystem dependency.
Bumped the version number.