### PR TITLE
avoid decoding more than once

### DIFF
--- a/lib/vector_tile_feature.dart
+++ b/lib/vector_tile_feature.dart
@@ -58,6 +58,9 @@ class VectorTileFeature {
   ///     var coordinates = (geometry as GeometryPoint).coordinates;
   ///    ```
   T? decodeGeometry<T extends Geometry?>() {
+    if (this.geometry != null) {
+      return this.geometry as T?;
+    }
     this.decodeProperties();
 
     switch (this.type) {
@@ -145,6 +148,9 @@ class VectorTileFeature {
   ///
   /// Return key/value pairs
   List<Map<String, VectorTileValue>> decodeProperties() {
+    if (this.properties != null) {
+      return this.properties!;
+    }
     int length = this.tags.length;
     List<Map<String, VectorTileValue>> properties = [];
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: vector_tile
-version: 0.2.1
+version: 0.2.2
 description: >-
   A simple Dart package to encode & decode Mapbox Vector Tile, A implementation of Mapbox Vector Tile specification.
 homepage: https://github.com/saigontek/dart-vector-tile


### PR DESCRIPTION
use fields if already computed