### PR TITLE
make storage of `VectorTileValue` more efficient

### DIFF
--- a/lib/vector_tile_layer.dart
+++ b/lib/vector_tile_layer.dart
@@ -1,6 +1,6 @@
 import 'package:vector_tile/raw/raw_vector_tile.dart' as raw;
-import 'package:vector_tile/vector_tile_geom_type.dart';
 import 'package:vector_tile/vector_tile_feature.dart';
+import 'package:vector_tile/vector_tile_geom_type.dart';
 import 'package:vector_tile/vector_tile_value.dart';
 
 class VectorTileLayer {
@@ -21,17 +21,8 @@ class VectorTileLayer {
   });
 
   static VectorTileLayer fromRaw({required raw.VectorTile_Layer rawLayer}) {
-    List<VectorTileValue> values = rawLayer.values.map((value) {
-      return VectorTileValue(
-        stringValue: value.hasStringValue() ? value.stringValue : null,
-        floatValue: value.hasFloatValue() ? value.floatValue : null,
-        doubleValue: value.hasDoubleValue() ? value.doubleValue : null,
-        intValue: value.hasIntValue() ? value.intValue : null,
-        uintValue: value.hasUintValue() ? value.uintValue : null,
-        sintValue: value.hasSintValue() ? value.sintValue : null,
-        boolValue: value.hasBoolValue() ? value.boolValue : null,
-      );
-    }).toList();
+    List<VectorTileValue> values =
+        rawLayer.values.map((value) => VectorTileValue.fromRaw(value)).toList();
     List<VectorTileFeature> features = rawLayer.features.map((feature) {
       return VectorTileFeature(
         id: feature.id,

--- a/lib/vector_tile_value.dart
+++ b/lib/vector_tile_value.dart
@@ -1,35 +1,132 @@
 import 'package:fixnum/fixnum.dart';
 import 'package:vector_tile/raw/raw_vector_tile.dart' as raw;
 
+enum ValueType {
+  string,
+  float,
+  double,
+  int,
+  uint,
+  sint,
+  bool,
+}
+
 class VectorTileValue {
-  String? stringValue;
-  double? floatValue;
-  double? doubleValue;
-  Int64? intValue;
-  Int64? uintValue;
-  Int64? sintValue;
-  bool? boolValue;
-  
-  VectorTileValue({
-    this.stringValue,
-    this.floatValue,
-    this.doubleValue,
-    this.intValue,
-    this.uintValue,
-    this.sintValue,
-    this.boolValue,
-  });
+  final ValueType type;
+  final Object value;
+
+  String? get stringValue {
+    final value = this.value;
+    return value is String ? value : null;
+  }
+
+  double? get floatValue {
+    final value = this.value;
+    return type == ValueType.float ? value as double : null;
+  }
+
+  double? get doubleValue {
+    final value = this.value;
+    return type == ValueType.double ? value as double : null;
+  }
+
+  Int64? get intValue {
+    final value = this.value;
+    return type == ValueType.int ? value as Int64 : null;
+  }
+
+  Int64? get uintValue {
+    final value = this.value;
+    return type == ValueType.uint ? value as Int64 : null;
+  }
+
+  Int64? get sintValue {
+    final value = this.value;
+    return type == ValueType.sint ? value as Int64 : null;
+  }
+
+  bool? get boolValue {
+    final value = this.value;
+    return value is bool ? value : null;
+  }
+
+  VectorTileValue.from(this.type, this.value);
+
+  factory VectorTileValue({
+    String? stringValue,
+    double? floatValue,
+    double? doubleValue,
+    Int64? intValue,
+    Int64? uintValue,
+    Int64? sintValue,
+    bool? boolValue,
+  }) {
+    if (stringValue != null) {
+      return VectorTileValue.from(ValueType.string, stringValue);
+    }
+    if (floatValue != null) {
+      return VectorTileValue.from(ValueType.float, floatValue);
+    }
+    if (doubleValue != null) {
+      return VectorTileValue.from(ValueType.double, doubleValue);
+    }
+    if (intValue != null) {
+      return VectorTileValue.from(ValueType.int, intValue);
+    }
+    if (uintValue != null) {
+      return VectorTileValue.from(ValueType.uint, uintValue);
+    }
+    if (sintValue != null) {
+      return VectorTileValue.from(ValueType.sint, sintValue);
+    }
+    if (boolValue != null) {
+      return VectorTileValue.from(ValueType.bool, boolValue);
+    }
+    throw ArgumentError('No value provided');
+  }
+
+  factory VectorTileValue.fromRaw(raw.VectorTile_Value value) {
+    if (value.hasStringValue()) {
+      return VectorTileValue.from(ValueType.string, value.stringValue);
+    }
+    if (value.hasFloatValue()) {
+      return VectorTileValue.from(ValueType.float, value.floatValue);
+    }
+    if (value.hasDoubleValue()) {
+      return VectorTileValue.from(ValueType.double, value.doubleValue);
+    }
+    if (value.hasIntValue()) {
+      return VectorTileValue.from(ValueType.int, value.intValue);
+    }
+    if (value.hasUintValue()) {
+      return VectorTileValue.from(ValueType.uint, value.uintValue);
+    }
+    if (value.hasSintValue()) {
+      return VectorTileValue.from(ValueType.sint, value.sintValue);
+    }
+    if (value.hasBoolValue()) {
+      return VectorTileValue.from(ValueType.bool, value.boolValue);
+    }
+    throw StateError('unreachable');
+  }
 
   raw.VectorTile_Value toRaw() {
-    return raw.VectorTile_Value(
-      stringValue: this.stringValue,
-      floatValue: this.floatValue,
-      doubleValue: this.doubleValue,
-      intValue: this.intValue,
-      uintValue: this.uintValue,
-      sintValue: this.sintValue,
-      boolValue: this.boolValue,
-    );
+    switch (type) {
+      case ValueType.string:
+        return raw.VectorTile_Value(stringValue: value as String);
+      case ValueType.float:
+        return raw.VectorTile_Value(floatValue: value as double);
+      case ValueType.double:
+        return raw.VectorTile_Value(doubleValue: value as double);
+      case ValueType.int:
+        return raw.VectorTile_Value(intValue: value as Int64);
+      case ValueType.uint:
+        return raw.VectorTile_Value(uintValue: value as Int64);
+      case ValueType.sint:
+        return raw.VectorTile_Value(sintValue: value as Int64);
+      case ValueType.bool:
+        return raw.VectorTile_Value(boolValue: value as bool);
+    }
   }
 
   String? get dartStringValue {
@@ -41,11 +138,7 @@ class VectorTileValue {
   }
 
   double? get dartDoubleValue {
-    if (this.floatValue != null) {
-      return this.floatValue!.toDouble();
-    }
-    
-    return this.doubleValue;
+    return this.floatValue ?? this.doubleValue;
   }
 
   bool? get dartBoolValue {


### PR DESCRIPTION
This change reduces the amount of storage required for a `VectorFileValue`.

Creating a `VectorTileValue` from  a raw `VectorTile_Value` is now slightly more efficient.

Users can now read the value of a `VectorTileValue` with a single load.