### PR TITLE
improve web platform compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ either `.pbf` or `.mvt` should work:
 import 'vector_tile/vector_tile.dart';
 
 main() async {
-  VectorTile tile = await VectorTile.fromPath(path: '../data/sample-12-3262-1923.pbf');
+  final tileData = await File('../data/sample-12-3262-1923.pbf').readAsBytes();
+  VectorTile tile = await VectorTile.fromPathfromBytes(bytes: tileData);
   VectorTileLayer layer = tile.layers.firstWhere((layer) => layer.name == 'transportation');
 
   layer.features.forEach((feature) {
@@ -74,7 +75,7 @@ main() async {
   var tile = createVectorTile(layers: layers);
 
   // Save to disk
-  await encodeVectorTile(path: './gen/tile.pbf', tile: tile);
+  await File('./gen/tile.pbf').writeAsBytes(tile.writeToBuffer());
 }
 ```
 

--- a/lib/raw/raw_vector_tile.dart
+++ b/lib/raw/raw_vector_tile.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:fixnum/fixnum.dart';
 import './proto/vector_tile.pb.dart';
 
@@ -92,24 +91,4 @@ VectorTile createVectorTile({
   required List<VectorTile_Layer> layers,
 }) {
   return VectorTile(layers: layers);
-}
-
-/// Encode `VectorTile` to buffer and then save it to disk
-Future<void> encodeVectorTile({
-  required String path,
-  required VectorTile tile,
-}) async {
-  File file = File(path);
-
-  await file.writeAsBytes(tile.writeToBuffer());
-}
-
-/// Read an vector tile (`.mvt`/`.pbf`) file from disk,
-/// Then decode it into `VectorTile` instance
-Future<VectorTile> decodeVectorTile({required String path}) async {
-  File file = File(path);
-
-  return VectorTile.fromBuffer(
-    await file.readAsBytes(),
-  );
 }

--- a/lib/vector_tile.dart
+++ b/lib/vector_tile.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -19,10 +18,6 @@ class VectorTile {
   VectorTile({
     required this.layers,
   });
-
-  static Future<VectorTile> fromPath({required String path}) async {
-    return fromBytes(bytes: await File(path).readAsBytes());
-  }
 
   /// decodes the given bytes (`.mvt`/`.pbf`) to a [VectorTile]
   static VectorTile fromBytes({required Uint8List bytes}) {


### PR DESCRIPTION
Improve web platform compatibility by
removing dart:io imports.
Removed corresponding file-based APIs.
Updated readme.

This is a small API-breaking change, but file-based APIs are pretty trivial to replicate outside of the library anyways.
if this PR is accepted, we should update the library major version.