### PR TITLE
Fix zigZagDecode for js targets

### DIFF
--- a/lib/util/command.dart
+++ b/lib/util/command.dart
@@ -19,11 +19,19 @@ class Command {
     );
   }
 
+  static final bool _isRunningAsJs = identical(0, 0.0);
+
   static int zigZagEncode(int val) {
     return (val << 1) ^ (val >> 31);
   }
 
   static int zigZagDecode(int parameterInteger) {
-    return ((parameterInteger >> 1) ^ (-(parameterInteger & 1)));
+    if (_isRunningAsJs) {
+      final isNegative = (parameterInteger & 1) == 1;
+      final base = parameterInteger ~/ 2;
+      return isNegative ? -base - 1 : base;
+    } else {
+      return ((parameterInteger >> 1) ^ (-(parameterInteger & 1)));
+    }
   }
 }


### PR DESCRIPTION
zigZagDecoding was not working for negative numbers on JS builds.

You can easily reproduce this on [dartpad.dev](https://dartpad.dev/) -

```
int oldDecoder(int parameterInteger) {
  return ((parameterInteger >> 1) ^ (-(parameterInteger & 1)));
}

int newDecoder(int parameterInteger) {
  final isNegative = (parameterInteger & 1) == 1;
  final base = parameterInteger ~/ 2;
  return isNegative ? -base - 1 : base;
}


void main() {
  for (int encodedNumber = 0; encodedNumber < 10; encodedNumber++)   {
    print("input: $encodedNumber => { was: ${oldDecoder(encodedNumber)}, fix: ${newDecoder(encodedNumber)}}");
  }
}
```

```
|input: 0 => { was: 0, fix: 0}
input: 1 => { was: 4294967295, fix: -1}
input: 2 => { was: 1, fix: 1}
input: 3 => { was: 4294967294, fix: -2}
input: 4 => { was: 2, fix: 2}
input: 5 => { was: 4294967293, fix: -3}
input: 6 => { was: 3, fix: 3}
input: 7 => { was: 4294967292, fix: -4}
input: 8 => { was: 4, fix: 4}
input: 9 => { was: 4294967291, fix: -5}
```