### PR TITLE
Update protobuf dependency for Dart 3/Flutter ecosystem

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: vector_tile
-version: 3.0.0
+version: 3.0.1
 description: >-
   A simple Dart package to encode & decode Mapbox Vector Tile, A implementation of Mapbox Vector Tile specification.
 homepage: https://github.com/saigontek/dart-vector-tile
@@ -8,6 +8,6 @@ environment:
   sdk: '>=3.8.1 <4.0.0'
 dependencies:
   fixnum: ^1.1.1
-  protobuf: ^4.1.1
+  protobuf: ^5.1.0
 dev_dependencies:
   lints: ^6.0.0


### PR DESCRIPTION
## Summary
- Update `vector_tile` to depend on `protobuf: ^5.1.0`.
- Bump package version to `3.0.1` to reflect the dependency compatibility update.
- This avoids resolver conflicts in apps that already use protobuf 5.x.

## Validation
- Ran `dart pub get` successfully.
- Ran `dart analyze` with no issues.


